### PR TITLE
fix: change title in header

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -65,7 +65,7 @@ const config = {
       // Replace with your project's social card
       image: "img/docusaurus-social-card.jpg",
       navbar: {
-        title: "RaspiBlitz",
+        title: "",
         logo: {
           alt: "RaspiBlitz logo",
           src: "img/RaspiBlitz_Logo_Main_Negative.svg",
@@ -75,7 +75,7 @@ const config = {
             type: "docSidebar",
             sidebarId: "blitzSidebar",
             position: "left",
-            label: "Tutorial",
+            label: "Documentation",
           },
           {
             href: "https://github.com/raspiblitz/raspiblitz",


### PR DESCRIPTION
Removed the `Raspiblitz` title from the header image and changed `Tutorial` to `Documentation`

## Before
![Screenshot 2024-10-09 at 08-22-09 Hello from RaspiBlitz RaspiBlitz](https://github.com/user-attachments/assets/8e21e9e2-82b4-42f0-91c7-56c07872958c)


## After

![Screenshot 2024-10-09 at 08-22-13 Hello from RaspiBlitz RaspiBlitz](https://github.com/user-attachments/assets/c93df721-0258-4b48-8140-0c02f8ad90c2)
